### PR TITLE
Add section on security

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,8 @@
 <section id="security" class="links close">
     <h2><i class="foundicon-lock"></i> <span>Securing your app</span></h2>
     <ol>
+        <li><a href="http://www.youtube.com/watch?v=zKuFu19LgZA">
+            Principles of Security <span>Douglas Crockford, youtube.com</span></a></li>
         <li><a href="https://github.com/eoftedal/writings/blob/master/published/javascript-security-cheat-sheet.md">
             Single Page Web App Security Cheat Sheet <span>Erlend Oftedal, github.com/eoftedal</span></a></li>
         <li><a href="http://shop.oreilly.com/product/9781593273880.do">

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
         <li><a href="#testing">Testing your application: Testable code, readable tests</a></li>
         <li><a href="#tools">Tools of the trade: Workflow, developer tools and debugging</a></li>
         <li><a href="#performance">Performance and Profiling: Fast and memory-efficient code</a></li>
+        <li><a href="#security">Securing your app: ...</a></li>
         <li><a href="#browser">Under the hood: Understanding the browser</a></li>
         <li><a href="#next">On the horizon: Stuff to keep an eye on</a></li>
         <li><a href="#resources">The league of awesome: Other superheroic resources</a></li>
@@ -172,6 +173,17 @@
             How (not) to trigger a layout in WebKit<span>Tony Gentilcore, gent.ilcore.com</span></a></li>
         <li><a href="http://shop.oreilly.com/product/9780596802806.do">
             <strong>Book</strong> High Performance JavaScript <span>Nicholas C. Zakas</span></a></li>
+    </ol>
+</section>
+
+
+<section id="security" class="links close">
+    <h2><i class="foundicon-lock"></i> <span>Securing your app</span></h2>
+    <ol>
+        <li><a href="https://github.com/eoftedal/writings/blob/master/published/javascript-security-cheat-sheet.md">
+            Single Page Web App Security Cheat Sheet <span>Erlend Oftedal, github.com/eoftedal</span></a></li>
+        <li><a href="http://shop.oreilly.com/product/9781593273880.do">
+            <strong>Book</strong> The Tangled Web <span>Michal Zalewski</span></a></li>
     </ol>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         <li><a href="#testing">Testing your application: Testable code, readable tests</a></li>
         <li><a href="#tools">Tools of the trade: Workflow, developer tools and debugging</a></li>
         <li><a href="#performance">Performance and Profiling: Fast and memory-efficient code</a></li>
-        <li><a href="#security">Securing your app: ...</a></li>
+        <li><a href="#security">Securing your app: Principles, access control and validation</a></li>
         <li><a href="#browser">Under the hood: Understanding the browser</a></li>
         <li><a href="#next">On the horizon: Stuff to keep an eye on</a></li>
         <li><a href="#resources">The league of awesome: Other superheroic resources</a></li>


### PR DESCRIPTION
We should have something on security. And it just didn't fit anywhere else. We'll have to gradually build it out.

We need something for the additional text in the ToC, any ideas?

(btw, I tagged 1.0, so it's easier to diff all the new stuff when we're sending the email newsletters)
