### PR TITLE
Normalize body font size using percentage instead

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,7 +15,7 @@ body {
     color:rgba(0,0,0,1);
     font-family: 'Source Sans Pro', sans-serif;
     font-weight: 400;
-    font-size:10px;
+    font-size:62.5%;
 }
 
 h1 {


### PR DESCRIPTION
TOC section is not displaying well in Firefox as the text is obscured by the background image.
![Screenshot in Firefox](https://f.cloud.github.com/assets/1570336/285806/0d9e8678-922a-11e2-8947-029b6a31aa48.png)

Problem due to different interpretations of font sizes, and thus ems, in different browsers.
