### PR TITLE
Added layout performance guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,8 @@
             with requestAnimationFrame <span>Paul Lewis, html5rocks.com</span></a></li>
         <li><a href="http://gent.ilcore.com/2011/03/how-not-to-trigger-layout-in-webkit.html">
             How (not) to trigger a layout in WebKit<span>Tony Gentilcore, gent.ilcore.com</span></a></li>
+        <li><a href="http://kellegous.com/j/2013/01/26/layout-performance/">
+            On Layout & Web Performance<span>Kelly Norton, kellegous.com</span></a></li>
         <li><a href="http://shop.oreilly.com/product/9780596802806.do">
             <strong>Book</strong> High Performance JavaScript <span>Nicholas C. Zakas</span></a></li>
     </ol>


### PR DESCRIPTION
This article is a good supplementary resource to 'How (not) to trigger layout in Webkit' that touches on using [Google Speed Tracer](https://developers.google.com/web-toolkit/speedtracer/) to diagnose and fix issues relating to layout/performance.
