### PR TITLE
Add A Drip of JavaScript to other resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,8 @@
             Mozilla Developer Network <span>Mozilla, mozilla.org</span></a></li>
         <li><a href="http://javascriptjabber.com/">
             JavaScript Jabber <span>javascriptjabber.com</span></a></li>
+        <li><a href="http://designpepper.com/a-drip-of-javascript/">
+            A Drip of JavaScript <span>Josh Clanton, designpepper.com</span></a></li>
     </ol>
 
     <h2 id="newsletter"><i class="foundicon-mail"></i> <span>Newsletter</span></h2>


### PR DESCRIPTION
A Drip of JavaScript is a newsletter focused on giving one short and sweet JS tip each week. You can look over past issues [here](http://designpepper.com/js-drip-archive/) to see if they meet your quality standards.
